### PR TITLE
Fix armv7l incorrect stack direction and stack reservation

### DIFF
--- a/cc.c
+++ b/cc.c
@@ -274,8 +274,7 @@ int main(int argc, char** argv)
 	}
 
 	if(Architecture == KNIGHT_NATIVE
-		|| Architecture == KNIGHT_POSIX
-		|| Architecture == ARMV7L)
+		|| Architecture == KNIGHT_POSIX)
 	{
 		stack_direction = STACK_DIRECTION_PLUS;
 	}

--- a/cc_core.c
+++ b/cc_core.c
@@ -521,9 +521,9 @@ void write_sub(int destination_reg, int source_reg, char* note)
 		emit_to_string("'0' ");
 		emit_to_string(destination_name);
 		emit_to_string(" ");
-		emit_to_string(destination_name);
-		emit_to_string(" SUB ");
 		emit_to_string(source_name);
+		emit_to_string(" SUB ");
+		emit_to_string(destination_name);
 		emit_to_string(" ARITH2_ALWAYS");
 	}
 	else if(AARCH64 == Architecture)


### PR DESCRIPTION
The sub mistakenly subtracted from the immediate value instead of subtracting from the stack value, leading to a negative address.

The stack direction was just incorrect.

@stikonas 