### PR TITLE
armv7l: Fix invalid load for immediates under 0

### DIFF
--- a/cc_core.c
+++ b/cc_core.c
@@ -286,7 +286,7 @@ void write_load_immediate(int reg, int value, char* note)
 	}
 	else if(ARMV7L == Architecture)
 	{
-		if((127 >= value) && (value >= -128))
+		if((127 >= value) && (value >= 0))
 		{
 			emit_to_string("!");
 			emit_to_string(value_string);


### PR DESCRIPTION
Using an assembler to load negative values into a register makes it use the `mvn` instruction instead of the `mov` instruction.

This makes it hang on test 0015.

```
LOAD:
mov r9, #4
mov r9, #127
mov r9, #-127
mov r9, #-1

arm-linux-gnueabi-as main-arm.s &&  arm-linux-gnueabi-objdump -d a.out

a.out:     file format elf32-littlearm

Disassembly of section .text:

00000000 <LOAD>:
   0:	e3a09004 	mov	r9, #4
   4:	e3a0907f 	mov	r9, #127	; 0x7f
   8:	e3e0907e 	mvn	r9, #126	; 0x7e
   c:	e3e09000 	mvn	r9, #0
```

@stikonas