### PR TITLE
Add proper error message for unterminated string

### DIFF
--- a/cc.h
+++ b/cc.h
@@ -164,5 +164,6 @@ struct static_variable_list
 };
 
 struct token_list* sym_declare(char *s, struct type* t, struct token_list* list, int options);
+void line_error_token(struct token_list* token);
 
 #include "cc_globals.h"

--- a/cc_reader.c
+++ b/cc_reader.c
@@ -67,7 +67,12 @@ int preserve_string(int c)
 		if(!escape && '\\' == c ) escape = TRUE;
 		else escape = FALSE;
 		c = consume_byte(c);
-		require(EOF != c, "Unterminated string\n");
+		if(EOF == c)
+		{
+			line_error_token(token);
+			fputs("Unterminated string\n", stderr);
+			exit(EXIT_FAILURE);
+		}
 	} while(escape || (c != frequent));
 	return grab_byte();
 }


### PR DESCRIPTION
Using `//` incorrectly can cause this issue. It's annoying to track down without this.