### PR TITLE
Fix indirect call clobbering function pointer on x86/amd64

### DIFF
--- a/cc_core.c
+++ b/cc_core.c
@@ -308,12 +308,15 @@ void function_call(struct token_list* s, int is_function_pointer)
 	emit_push(REGISTER_BASE, "Protect the old base pointer");
 	emit_push(REGISTER_LOCALS, "Protect the old locals pointer");
 
-	emit_move(REGISTER_TEMP, REGISTER_STACK, "Copy new base pointer");
-
+	/* Spill the function pointer to the stack instead of a register.
+	 * On x86 REGISTER_TEMP2 is EDX, which is implicitly written by mul
+	 * (used to scale array subscripts) when evaluating arguments. */
 	if(is_function_pointer)
 	{
-		emit_move(REGISTER_TEMP2, REGISTER_ZERO, "Save function pointer address");
+		emit_push(REGISTER_ZERO, "Save function pointer on stack");
 	}
+
+	emit_move(REGISTER_TEMP, REGISTER_STACK, "Copy new base pointer");
 
 	int passed = 0;
 	while(global_token->s[0] != ')')
@@ -340,7 +343,8 @@ void function_call(struct token_list* s, int is_function_pointer)
 
 	if(TRUE == is_function_pointer)
 	{
-		emit_move(REGISTER_ZERO, REGISTER_TEMP2, "Restore function pointer");
+		emit_load_relative_to_register(REGISTER_ZERO, REGISTER_TEMP, 0, "Address of saved function pointer");
+		emit_dereference(REGISTER_ZERO, "Restore function pointer from stack");
 
 		if(Architecture & ARCH_FAMILY_KNIGHT)
 		{
@@ -405,6 +409,11 @@ void function_call(struct token_list* s, int is_function_pointer)
 	if(passed > 0)
 	{
 		emit_move(REGISTER_STACK, REGISTER_BASE, "Clean up function arguments");
+	}
+
+	if(is_function_pointer)
+	{
+		emit_pop(REGISTER_ONE, "Discard saved function pointer slot");
 	}
 
 	emit_pop(REGISTER_LOCALS, "Restore old locals pointer");

--- a/test/run-pass/function_pointer_args.c
+++ b/test/run-pass/function_pointer_args.c
@@ -1,0 +1,42 @@
+/* Copyright (C) 2026 Ben Siraphob
+ * This file is part of M2-Planet.
+ *
+ * M2-Planet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * M2-Planet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+typedef int (*FUNCTION)(int);
+
+int table[3];
+
+int indexed_get(int i) {
+	return table[i];
+}
+
+int identity(int x) {
+	return x;
+}
+
+int main() {
+	FUNCTION fp;
+
+	table[0] = 100;
+	table[1] = 200;
+	table[2] = 300;
+
+	fp = identity;
+
+	if(fp(table[2]) != 300) return 1;
+	if(fp(indexed_get(1)) != 200) return 2;
+	if(fp(indexed_get(table[0] - 100)) != 100) return 3;
+}


### PR DESCRIPTION
`function_call` spills the function pointer to `REGISTER_TEMP2` (`EDX`/`RDX`) across argument evaluation. The single-operand `mul` that `emit_mul_into_register_zero` emits for array subscripts implicitly writes `EDX:EAX`, so any `fp(arr[i])` or `fp(g())` where `g()` does array indexing ends up calling through whatever `mul` left in `EDX`, typically zero.

Reproducer:

```c
typedef unsigned (*FUNCTION)(unsigned);
unsigned table[1];
unsigned get(unsigned i) { return table[i]; }
unsigned sink(unsigned x) { return x; }
int main() { FUNCTION fp = sink; fp(get(0)); return 0; }
```

Segfaults on current `master`, exits 0 with this patch.

Regression from be4951f ("Refactor variable load out of function_call"). Before that commit the pointer was reloaded from its source variable after argument evaluation, so register clobbers were harmless. `test/run-pass/function_pointers.c` only exercises zero-argument calls, which is why CI did not catch it.

The fix spills to the stack at `[REGISTER_TEMP + 0]` instead. The second commit adds a `run-pass` test covering `fp(arr[i])`, `fp(g())` and `fp(g(arr[i]))`, which segfaults without the fix.

Surfaced while building `oriansj/blynn-compiler` `vm.c`, which calls `put(num(1))` where `num(n)` returns `mem[arg(n) + 1]`.

@stikonas @oriansj
