### PR TITLE
fix &array[i] to yield the element's address, not its value

### DIFF
--- a/cc_core.c
+++ b/cc_core.c
@@ -1146,6 +1146,7 @@ void postfix_expr_dot(void)
 void postfix_expr_array(void)
 {
 	char* prefix_operator = global_token->prev->prev->s;
+	int was_address_of = Address_of;
 
 	struct type* array = current_target;
 	common_recursion(expression);
@@ -1171,7 +1172,7 @@ void postfix_expr_array(void)
 
 	int is_prefix_operator = match("++", prefix_operator) || match("--", prefix_operator);
 	int is_postfix_operator = match("++", global_token->s) || match("--", global_token->s);
-	if(match("=", global_token->s) || is_compound_assignment(global_token->s) || match(".", global_token->s) || is_prefix_operator || is_postfix_operator)
+	if(match("=", global_token->s) || is_compound_assignment(global_token->s) || match(".", global_token->s) || is_prefix_operator || is_postfix_operator || was_address_of)
 	{
 		assign = "";
 	}

--- a/test/run-pass/address_of_array_element.c
+++ b/test/run-pass/address_of_array_element.c
@@ -1,0 +1,17 @@
+/* &array[element] must evaluate to the element's address, not its value. */
+
+int get(int* p)
+{
+	return p[0];
+}
+
+int main()
+{
+	int b[4];
+	b[1] = 42;
+	if(get(&b[1]) != 42)
+	{
+		return 1;
+	}
+	return 0;
+}


### PR DESCRIPTION
postfix_expr_array() loaded the element even under unary &; honor the Address_of flag, captured before the subscript parse clears it.